### PR TITLE
Extra args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add GitLab support
 - Add `--dry-run` to display the used data before creating the PR
 - Rename build executable script to `create-pr`
+- Allow passing extra arguments to the `gh` or `glab` tools
 
 ## [0.5](https://github.com/Chemaclass/create-pr/compare/0.15.0...0.16.0) - 2024-09-09
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ PR_LABEL_MAPPING="docs:documentation; fix|bug|bugfix|hotfix:bug; default:enhance
 
 - `BASE_BRANCH` or `main` by default
 
+## Extra arguments
+
+Any additional argument will be passed to `gh` or `glab` tool.
+
+> Eg: `create-pr --draft` will create a draft PR.
+
 ## HINTS
 
 - Add to your composer, npm or similar a script pointing to the `create-pr`

--- a/create-pr
+++ b/create-pr
@@ -19,6 +19,7 @@ source "$CREATE_PR_ROOT_DIR/src/console_header.sh"
 source "$CREATE_PR_ROOT_DIR/src/main.sh"
 
 DRY_RUN=${DRY_RUN:-false}
+EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   argument="$1"
@@ -46,6 +47,8 @@ while [[ $# -gt 0 ]]; do
       console_header::print_help
       trap '' EXIT && exit 0
       ;;
+    *)
+      EXTRA_ARGS+=("$argument")
   esac
   shift
 done
@@ -55,6 +58,11 @@ PR_TITLE=$(pr_title "$BRANCH_NAME")
 PR_BODY=$(pr_body "$BRANCH_NAME" "$PR_TEMPLATE")
 
 if [[ "$DRY_RUN" == true ]]; then
+  if [ ${#EXTRA_ARGS[@]} -gt 0 ]; then
+    printf "EXTRA_ARGS: %s\n" "${EXTRA_ARGS[@]}"
+  else
+    printf "EXTRA_ARGS: empty\n"
+  fi
   printf "REMOTE_URL: %s\n" "$REMOTE_URL"
   printf "BRANCH_NAME: %s\n" "$BRANCH_NAME"
   printf "PR_USING_CLIENT: %s\n" "$PR_USING_CLIENT"

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,12 +20,16 @@ function main::create_pr() {
 
 function main::create_pr_gitlab() {
   validate_glab_cli_is_installed
+  : "${EXTRA_ARGS:=()}"
+
   if glab mr create --title "$PR_TITLE" \
                       --target-branch "$BASE_BRANCH" \
                       --source-branch "$BRANCH_NAME" \
                       --assignee "$PR_ASSIGNEE" \
                       --label "$PR_LABEL" \
-                      --description "$PR_BODY"; then
+                      --description "$PR_BODY" \
+                      "${EXTRA_ARGS[@]}" \
+  ; then
     echo "Merge Request created successfully."
   else
     error_and_exit "Failed to create the Merge Request." \
@@ -35,13 +39,17 @@ function main::create_pr_gitlab() {
 
 function main::create_pr_github() {
   validate_gh_cli_is_installed
+  : "${EXTRA_ARGS:=()}"
+
   # Create the PR with the specified options
   if ! gh pr create --title "$PR_TITLE" \
                     --base "$BASE_BRANCH" \
                     --head "$BRANCH_NAME" \
                     --assignee "$PR_ASSIGNEE" \
                     --label "$PR_LABEL" \
-                    --body "$PR_BODY"; then
+                    --body "$PR_BODY" \
+                    "${EXTRA_ARGS[@]}" \
+  ; then
       error_and_exit "Failed to create the pull request."\
         "Ensure you have the correct permissions and the repository is properly configured."
   fi

--- a/tests/e2e/create-pr_test.sh
+++ b/tests/e2e/create-pr_test.sh
@@ -27,3 +27,10 @@ function test_script_with_dry_run() {
 
   assert_match_snapshot "$($SCRIPT --dry-run)"
 }
+
+function test_script_with_dry_run_and_extra_args() {
+  spy git
+  spy gh
+
+  assert_match_snapshot "$($SCRIPT --dry-run --draft "--title \"Pull request title\"")"
+}

--- a/tests/e2e/snapshots/create_pr_test_sh.test_script_with_dry_run_and_extra_args.snapshot
+++ b/tests/e2e/snapshots/create_pr_test_sh.test_script_with_dry_run_and_extra_args.snapshot
@@ -1,4 +1,5 @@
-EXTRA_ARGS: empty
+EXTRA_ARGS: --draft
+EXTRA_ARGS: --title "Pull request title"
 REMOTE_URL: git@github.com:Chemaclass/create-pr.git
 BRANCH_NAME: feat/ticket-123-my_branch-name
 PR_USING_CLIENT: github


### PR DESCRIPTION
## 🤔 Background

The original gh or glab tools accept many other arguments to interact with when creating a PR/MR. 
Eg: `--draft` to mark the PR as draft. 

> Idea from @pavelmaksimov25

## 💡 Goal

Enable passing extra arguments to the script.

## 🔖 Changes

- Allow passing extra arguments to the script, and pass them to the actual [gh](https://github.com/cli/cli) or [glab](https://docs.gitlab.com/ee/editor_extensions/gitlab_cli/) tools.

## 🖼️ Demo

Creating this PR as draft using `--draft` option when running the `create-pr` script.

<img width="936" alt="Screenshot 2024-09-15 at 15 03 44" src="https://github.com/user-attachments/assets/d1b80f17-b92a-4780-bcaf-cc4949475419">

![Screenshot 2024-09-15 at 15 06 38](https://github.com/user-attachments/assets/b917ee4b-dd82-46b5-b779-06c33c8e54ea)
