### PR TITLE
Use ticket number only at the beggining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `PR_TITLE_REMOVE_PREFIX`
+- Use ticket number only at the beginning of branch name
 
 ## [0.7](https://github.com/Chemaclass/create-pr/compare/0.6...0.7) - 2024-09-29
 

--- a/src/pr_ticket.sh
+++ b/src/pr_ticket.sh
@@ -4,7 +4,20 @@ set -o allexport
 # $1 = branch_name
 function pr_ticket::number() {
   branch_name=$1
-  echo "$branch_name" | grep -oE "[0-9]+" | head -n 1
+
+  # Remove optional prefix and split the branch name by hyphens
+  stripped_branch=${branch_name#*/}
+  # shellcheck disable=SC2206
+  parts=(${stripped_branch//-/ })
+
+  # Check if the first or second part contains a number and print it; otherwise, print an empty string
+  if [[ ${parts[0]} =~ ^[0-9]+$ ]]; then
+    echo "${parts[0]}"
+  elif [[ ${parts[1]} =~ ^[0-9]+$ ]]; then
+    echo "${parts[1]}"
+  else
+    echo ""
+  fi
 }
 
 # $1 = branch_name

--- a/tests/unit/pr_ticket_number_test.sh
+++ b/tests/unit/pr_ticket_number_test.sh
@@ -5,7 +5,11 @@ function set_up() {
   source "$CREATE_PR_ROOT_DIR/src/pr_ticket.sh"
 }
 
-function test_pr_ticket_number_default() {
+function test_pr_ticket_number_start_with_number() {
+  assert_same "123" "$(pr_ticket::number "123-TICKET-my-branch_name")"
+}
+
+function test_pr_ticket_number_after_ticket_key() {
   assert_same "123" "$(pr_ticket::number "TICKET-123-my-branch_name")"
 }
 
@@ -29,17 +33,14 @@ function test_pr_ticket_number_with_numbers_in_branch_name() {
   assert_same "123" "$(pr_ticket::number "Ticket-123-my-2-nd-branch_name")"
 }
 
-# data_provider provide_ticket_number_only_at_the_beginning
-function test_pr_ticket_number_only_at_the_beginning() {
-  local branch_name="$1"
-
-  assert_empty "$(pr_ticket::number "$branch_name")"
+function test_pr_ticket_number_without_number() {
+  assert_empty "$(pr_ticket::number "creating-my-branch_name")"
 }
 
-function provide_ticket_number_only_at_the_beginning() {
-  echo "creating-my-branch_name"
-  echo "creating-my-2-nd-branch_name"
-  echo "TICKET-my-2-nd-branch_name"
-  echo "feat/creating-my-2-nd-branch_name"
-  echo "feat/TICKET-my-2-nd-branch_name"
+function test_pr_ticket_number_with_number_not_in_first_nor_second_pos() {
+  assert_empty "$(pr_ticket::number "creating-my-2-nd-branch_name")"
+}
+
+function test_pr_ticket_number_with_prefix_and_number_not_in_first_nor_second_pos() {
+  assert_empty "$(pr_ticket::number "feat/creating-my-2-nd-branch_name")"
 }

--- a/tests/unit/pr_ticket_number_test.sh
+++ b/tests/unit/pr_ticket_number_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2034
 
 function set_up() {
   source "$CREATE_PR_ROOT_DIR/src/pr_ticket.sh"
@@ -26,4 +27,19 @@ function test_pr_ticket_number_lower_upper_case() {
 
 function test_pr_ticket_number_with_numbers_in_branch_name() {
   assert_same "123" "$(pr_ticket::number "Ticket-123-my-2-nd-branch_name")"
+}
+
+# data_provider provide_ticket_number_only_at_the_beginning
+function test_pr_ticket_number_only_at_the_beginning() {
+  local branch_name="$1"
+
+  assert_empty "$(pr_ticket::number "$branch_name")"
+}
+
+function provide_ticket_number_only_at_the_beginning() {
+  echo "creating-my-branch_name"
+  echo "creating-my-2-nd-branch_name"
+  echo "TICKET-my-2-nd-branch_name"
+  echo "feat/creating-my-2-nd-branch_name"
+  echo "feat/TICKET-my-2-nd-branch_name"
 }

--- a/tests/unit/pr_title_test.sh
+++ b/tests/unit/pr_title_test.sh
@@ -73,6 +73,12 @@ function test_pr_title_with_prefix_and_ticket_number() {
   assert_same "Add pr 3 create Script" "$actual"
 }
 
+function test_pr_title_ticket_number_only_at_the_beginning() {
+  actual=$(pr_title "prefix/add-pr-3-create_script")
+
+  assert_same "Add pr 3 create Script" "$actual"
+}
+
 function test_pr_title_with_prefix_and_ticket_key() {
   actual="$(pr_title "feat/TICKET-my-branch_name")"
 


### PR DESCRIPTION

## 🤔 Background

Sometimes there is no ticket assigned to the PR but the branch contains a number in the middle of the branch name.

## 🔖 Changes

Use the ticket number only from the first or second position of the branch name (ignoring the optional prefix)
